### PR TITLE
Data root updation in shap-agg-eval.py

### DIFF
--- a/shap-agg-eval.py
+++ b/shap-agg-eval.py
@@ -38,7 +38,7 @@ model.eval()
 model = model.to(device)
 
 
-DATA_ROOT = # fill here
+DATA_ROOT = "data/ukb_simulated_data"
 
 train = np.fromfile(f'{DATA_ROOT}/train.bin', dtype=np.uint32).reshape(-1,3)
 val = np.fromfile(f'{DATA_ROOT}/val.bin', dtype=np.uint32).reshape(-1,3)


### PR DESCRIPTION
Data root was not given in the variable, just a comment #fill here was written which can be confusing that's why i've added the data root corresponding to the code file.