### PR TITLE
Update example_ukb_to_bin.ipynb to fix a sort error

### DIFF
--- a/data/ukb_simulated_data/example_ukb_to_bin.ipynb
+++ b/data/ukb_simulated_data/example_ukb_to_bin.ipynb
@@ -177,7 +177,7 @@
     "data = data.astype(np.uint32)\n",
     "data.tofile(output_prefix + '.bin')\n",
     "ids = list(set(data[:,0]))\n",
-    "ids = ids.sort()\n",
+    "ids.sort()\n",
     "train_val_split = data[:,0] <= ids[int(len(ids)*train_proportion)]\n",
     "data[train_val_split].tofile(output_prefix + '_train.bin')\n",
     "data[~train_val_split].tofile(output_prefix + '_val.bin')\n"


### PR DESCRIPTION
Hi, in the original example of Delphi, the sort function is wrongly applied. Since .sort() opterats the targeted variable in its original memory, there is no return value.