### PR TITLE
Maint: Update PyTorch APIs to resolve deprecation warnings

### DIFF
--- a/train.py
+++ b/train.py
@@ -76,14 +76,8 @@ config = {k: globals()[k] for k in config_keys}  # will be useful for logging
 os.makedirs(out_dir, exist_ok=True)
 torch.manual_seed(seed)
 
-# Use the new API for controlling TF32 precision, as the old
-# allow_tf32 settings will be deprecated after PyTorch 2.9 (see warning).
-torch.backends.cuda.matmul.fp32_precision = 'tf32' # enable TF32 for matrix multiplication
-torch.backends.cudnn.conv.fp32_precision = 'tf32'  # enable TF32 for cudnn convolutions
-
-# Original lines were
-# torch.backends.cuda.matmul.allow_tf32 = True  # allow tf32 on matmul
-# torch.backends.cudnn.allow_tf32 = True  # allow tf32 on cudnn
+torch.backends.cuda.matmul.fp32_precision = 'tf32'
+torch.backends.cudnn.conv.fp32_precision = 'tf32'
 
 device_type = 'cuda' if 'cuda' in device else 'cpu'  # for later use in torch.autocast
 # note: float16 data type will automatically use a GradScaler
@@ -151,7 +145,6 @@ model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
 scaler = torch.amp.GradScaler('cuda', enabled=(dtype == 'float16')) 
-# Original: scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)

--- a/train.py
+++ b/train.py
@@ -75,10 +75,8 @@ config = {k: globals()[k] for k in config_keys}  # will be useful for logging
 
 os.makedirs(out_dir, exist_ok=True)
 torch.manual_seed(seed)
-
 torch.backends.cuda.matmul.fp32_precision = 'tf32'
 torch.backends.cudnn.conv.fp32_precision = 'tf32'
-
 device_type = 'cuda' if 'cuda' in device else 'cpu'  # for later use in torch.autocast
 # note: float16 data type will automatically use a GradScaler
 ptdtype = {'float32': torch.float32, 'float64': torch.float64,

--- a/train.py
+++ b/train.py
@@ -75,8 +75,16 @@ config = {k: globals()[k] for k in config_keys}  # will be useful for logging
 
 os.makedirs(out_dir, exist_ok=True)
 torch.manual_seed(seed)
-torch.backends.cuda.matmul.allow_tf32 = True  # allow tf32 on matmul
-torch.backends.cudnn.allow_tf32 = True  # allow tf32 on cudnn
+
+# Use the new API for controlling TF32 precision, as the old
+# allow_tf32 settings will be deprecated after PyTorch 2.9 (see warning).
+torch.backends.cuda.matmul.fp32_precision = 'tf32' # enable TF32 for matrix multiplication
+torch.backends.cudnn.conv.fp32_precision = 'tf32'  # enable TF32 for cudnn convolutions
+
+# Original lines were
+# torch.backends.cuda.matmul.allow_tf32 = True  # allow tf32 on matmul
+# torch.backends.cudnn.allow_tf32 = True  # allow tf32 on cudnn
+
 device_type = 'cuda' if 'cuda' in device else 'cpu'  # for later use in torch.autocast
 # note: float16 data type will automatically use a GradScaler
 ptdtype = {'float32': torch.float32, 'float64': torch.float64,
@@ -142,7 +150,8 @@ elif init_from == 'resume':
 model.to(device)
 
 # initialize a GradScaler. If enabled=False scaler is a no-op
-scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
+scaler = torch.amp.GradScaler('cuda', enabled=(dtype == 'float16')) 
+# Original: scaler = torch.cuda.amp.GradScaler(enabled=(dtype == 'float16'))
 
 # optimizer
 optimizer = model.configure_optimizers(weight_decay, learning_rate, (beta1, beta2), device_type)


### PR DESCRIPTION
Updates both deprecated (GradScaler) and soon-to-be deprecated (TF32 config) APIs for future PyTorch compatibility